### PR TITLE
Add deploy info, snippet script, revert base URL

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Setup Node
@@ -28,6 +28,9 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Create embed snippet
+        run: npm run snippet
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BTS Rider Site
+# BTS Ticketing App
 
 Production URLs:
 
@@ -14,7 +14,7 @@ Netlify dashboard: https://app.netlify.com/sites/cosmic-kataifi-559176/
 * Node v16.20
 * npm v8.19
 
-### Setup
+### Setup/run
 
 1. Install the dependencies with `npm install`
 
@@ -23,7 +23,50 @@ Netlify dashboard: https://app.netlify.com/sites/cosmic-kataifi-559176/
 3. Ensure the API is listening on http://localhost:3000/ and browse to
    http://localhost:4200/tickets/
 
-## More info
+### Test
+
+Run the unit tests with `npm test`.
+
+### Build/serve/deploy
+
+Create a production build with `npm run build`.
+
+The resulting build directory can be served on localhost with `npx run serve -s build -l 4200`.
+
+The build directory can also be deployed to production, but this step is unnecessary as any
+push/merge to the main branch will do so automatically via GitHub Actions.
+
+After deploying, the page hosting the app must be updated with the new JS/CSS file URLs as
+described below.
+
+### BTS Homepage integration
+
+The production build is served by GitHub Pages at https://bus-to-show.github.io/bus-to-show-react/.
+
+The bundled JS and CSS files are then injected into the page at https://bustoshow.org/tickets/.
+These file names change with every deployment and have to be updated manually (for now).
+
+You can see the new file names in the build log, e.g.:
+
+```
+$ npm run build
+
+> bus-to-show@0.1.0 build
+> react-scripts build
+
+Creating an optimized production build...
+Compiled successfully.
+
+File sizes after gzip:
+
+  154.21 kB (-12 B)  build/static/js/main.b4a3efa4.js
+  2.14 kB            build/static/css/main.a8d72baf.css
+```
+
+You can also find the new file names by browsing the gh-pages branch, or by going to
+https://bus-to-show.github.io/bus-to-show-react/ and inspecting the markup.
+
+### Useful links
 
 * [Environment Variables](https://create-react-app.dev/docs/adding-custom-environment-variables/)
   * Also see [Advanced Configuration](https://create-react-app.dev/docs/advanced-configuration/)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Production URLs:
 
-* https://bustoshow.org/tickets/
-* https://cosmic-kataifi-559176.netlify.app/tickets/
+* https://bustoshow.org/
+* https://cosmic-kataifi-559176.netlify.app/
 
 Netlify dashboard: https://app.netlify.com/sites/cosmic-kataifi-559176/
 
@@ -21,7 +21,7 @@ Netlify dashboard: https://app.netlify.com/sites/cosmic-kataifi-559176/
 2. Run the site with `npm start`
 
 3. Ensure the API is listening on http://localhost:3000/ and browse to
-   http://localhost:4200/tickets/
+   http://localhost:4200/
 
 ### Test
 
@@ -43,7 +43,7 @@ described below.
 
 The production build is served by GitHub Pages at https://bus-to-show.github.io/bus-to-show-react/.
 
-The bundled JS and CSS files are then injected into the page at https://bustoshow.org/tickets/.
+The bundled JS and CSS files are then injected into the page at https://bustoshow.org/.
 These file names change with every deployment and have to be updated manually (for now).
 
 You can see the new file names in the build log, e.g.:

--- a/create-embed-snippet.mjs
+++ b/create-embed-snippet.mjs
@@ -1,0 +1,23 @@
+import { JSDOM } from 'jsdom';
+import { open } from 'node:fs/promises';
+
+const inPath = 'build/index.html';
+const dom = await JSDOM.fromFile(inPath);
+
+const outPath = 'build/embed-snippet.html';
+const outFile = await open(outPath, 'w');
+const outStream = outFile.createWriteStream();
+
+const links = dom.window.document.querySelectorAll('link[rel=stylesheet]');
+
+for (const link of links) {
+  outStream.write(link.outerHTML + '\n');
+}
+
+outStream.write('<div id="root">Insert app here</div>\n');
+
+const scripts = dom.window.document.querySelectorAll('script');
+
+for (const script of scripts) {
+  outStream.write(script.outerHTML + '\n');
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "snippet": "node create-embed-snippet.mjs"
   },
   "eslintConfig": {
     "extends": "react-app",

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,6 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no, maximum-scale=1, user-scalable=no"
     />
-    <!-- <meta name="viewport" content="width=device-width, shrink-to-fit=yes" /> -->
     <meta name="theme-color" content="#000000" />
     <meta
       property="og:site_name"
@@ -31,7 +30,7 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link
       rel="stylesheet"
-      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@4.3.1/dist/css/bootstrap.min.css"
       integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
       crossorigin="anonymous"
     />
@@ -58,26 +57,16 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
+      src="https://cdn.jsdelivr.net/npm/popper.js@1.14.7/dist/umd/popper.min.js"
       integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+      src="https://cdn.jsdelivr.net/npm/bootstrap@4.3.1/dist/js/bootstrap.min.js"
       integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
       crossorigin="anonymous"
     ></script>
-
-    <!-- <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
-    crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q"
-    crossorigin="anonymous"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
-    crossorigin="anonymous"></script> -->
-    <script
-      src="https://apis.google.com/js/platform.js?onload=onLoadCallback"
-      async=""
-    ></script>
-    <script src="https://js.stripe.com/v3/"></script>
+    <script src="https://apis.google.com/js/platform.js?onload=onLoadCallback" async></script>
+    <script src="https://js.stripe.com/v3/" async></script>
   </body>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -386,7 +386,7 @@ const App = (props) => {
   }, []);
 
   return (
-    <Router basename="/tickets">
+    <Router>
       <div>
         {!headerHidden ? (
           <Header


### PR DESCRIPTION
You can see from the info in README the steps involved in updating the app on the homepage. It's brittle and a PITA.

`npm run snippet` aims to solve this by creating a file in the build directory that we can load on the homepage like this:

```js
const response = await fetch('https://bus-to-show.github.io/bus-to-show-react/embed-snippet.html');
document.getElementById('content').innerHTML = response.text();
```

As for the base URL change, I was able to convince Amandine the app should be on the homepage root and not a subpath.