### PR TITLE
Display card declined error when purchase fails for any reason

### DIFF
--- a/src/Components/Cart/Cart.js
+++ b/src/Components/Cart/Cart.js
@@ -78,31 +78,36 @@ const Cart = (props) => {
             </div>
             :
             <div className="list-group">
-              {props.displayWarning || props.purchasePending || props.purchaseSuccessful || props.displayConfirmRemove ?
+              {props.displayWarning || props.purchasePending || props.purchaseFailed || props.displayConfirmRemove ? (
                 <div className="row">
                   <div className="col-md-12">
-                    {props.displayWarning ? <div className="alert alert-warning mb-2" role="alert">
-                      <h6 className="warning-text">
-                        We are currently only able to process orders for one event at a time.  Please either complete your reservation for this event, or click “cancel order”  to change qty or start over with a different event.
-                      </h6>
-                      <div className="warning-btns">
-                        <button onClick={props.removeFromCart} type="button" className="btn btn-sm btn-danger mr-2">Cancel & Start Over</button>
-                        <button onClick={props.closeAlert} type="button" className="btn btn-sm btn-success">Continue With Order</button>
+                    {props.displayWarning ? (
+                      <div className="alert alert-warning mb-2" role="alert">
+                        <h6 className="warning-text">
+                          We are currently only able to process orders for one event at a time. Please either complete your reservation for this event, or click "cancel order" to change qty or start over with a different event.
+                        </h6>
+                        <div className="warning-btns">
+                          <button onClick={props.removeFromCart} type="button" className="btn btn-sm btn-danger mr-2">Cancel & Start Over</button>
+                          <button onClick={props.closeAlert} type="button" className="btn btn-sm btn-success">Continue With Order</button>
+                        </div>
                       </div>
-                    </div> : ''}
-                    {(props.purchasePending && !props.purchaseFailed) ?
-                    <div className="alert alert-primary" role="alert"> Purchase Pending... </div>
-                    :
-                    (props.purchasePending && props.purchaseFailed ?
-                      <div className="alert alert-danger" role="alert"> Payment Declined, Please Try Another Card or Something. </div> : '')}
-                    {props.displayConfirmRemove ? <div className="alert alert-danger" role="alert">
-                      Are you sure you want to remove item from cart?
-                    <button onClick={props.confirmedRemove} type="button" className="btn btn-danger ml-1">Remove</button>
-                      <button onClick={props.closeAlert} type="button" className="btn btn-outline-secondary ml-1">Continue Order</button>
-                    </div> : ''}
+                    ) : ''}
+                    {props.purchasePending ? (
+                      <div className="alert alert-primary" role="alert">Purchase Pending...</div>
+                    ) : ''}
+                    {props.purchaseFailed ? (
+                      <div className="alert alert-danger" role="alert">Payment Declined, Please Try Another Card or Something.</div>
+                    ) : ''}
+                    {props.displayConfirmRemove ? (
+                      <div className="alert alert-danger" role="alert">
+                        Are you sure you want to remove item from cart?
+                        <button onClick={props.confirmedRemove} type="button" className="btn btn-danger ml-1">Remove</button>
+                        <button onClick={props.closeAlert} type="button" className="btn btn-outline-secondary ml-1">Continue Order</button>
+                      </div>
+                    ) : ''}
                   </div>
                 </div>
-                : ''}
+              ) : ''}
 
               <div className="row">
                 <div className="col-md-12">

--- a/src/Components/DetailCartView.js
+++ b/src/Components/DetailCartView.js
@@ -73,6 +73,7 @@ const DetailCartView = (props) => {
                   pickupPartyId={props.pickupPartyId}
                   purchase={props.purchase}
                   purchaseClick={props.purchaseClick}
+                  purchaseFailed={props.purchaseFailed}
                   purchasePending={props.purchasePending}
                   purchaseSuccessful={props.purchaseSuccessful}
                   removeFromCart={props.removeFromCart}

--- a/src/Pages/LayoutPage.js
+++ b/src/Pages/LayoutPage.js
@@ -849,10 +849,10 @@ class LayoutPage extends Component {
     this.ticketTimer(false)
     if (err) {
       console.log('purchase error', err)
-      await this.ticketTimer(false)
-      await this.ticketTimer(true, 360000, true) // production
+      this.ticketTimer(false)
+      this.ticketTimer(true, 360000, true) // production
       //await this.ticketTimer(true, 30000, true) //testing
-      return this.setState({ purchaseFailed: true })
+      return this.setState({ purchaseFailed: true, purchasePending: false })
     }
     const cartObj = this.state.cartToSend
     cartObj.discountCode = this.state.afterDiscountObj.discountCodeId
@@ -869,6 +869,7 @@ class LayoutPage extends Component {
 
     this.setState({
       purchaseSuccessful: true,
+      purchaseFailed: false,
       purchasePending: false,
       inCart: [],
       ticketQuantity: null,
@@ -1028,14 +1029,12 @@ class LayoutPage extends Component {
 
   removeFromCart = () => {
     const newState = { ...this.state }
-    newState.purchaseSuccessful = false
     newState.displayWarning = false
     newState.displayConfirmRemove = true
 
     this.setState({
       displayConfirmRemove: newState.displayConfirmRemove,
       displayWarning: newState.displayWarning,
-      purchaseSuccessful: newState.purchaseSuccessful,
     })
 
     window.removeEventListener("beforeunload", this.clearCartOnClose)
@@ -1064,6 +1063,7 @@ class LayoutPage extends Component {
     newState.pickupLocationId = null
     newState.validated = false
     newState.purchasePending = false
+    newState.purchaseFailed = false
     newState.discountApplied = false
     newState.discountCode = null
     newState.afterDiscountObj = {}
@@ -1079,6 +1079,7 @@ class LayoutPage extends Component {
       startTimer: newState.startTimer,
       ticketQuantity: newState.ticketQuantity,
       purchasePending: newState.purchasePending,
+      purchaseFailed: newState.purchaseFailed,
       discountApplied: newState.discountApplied,
       discountCode: newState.discountCode,
       afterDiscountObj: newState.afterDiscountObj,


### PR DESCRIPTION
Ideally we'd show the error message returned from the API, but that's more work.

Depends on Bus-to-Show/bts-back-2025#16.